### PR TITLE
Fix UCE in switch statement

### DIFF
--- a/src/__tests__/1_astTools.spec.ts
+++ b/src/__tests__/1_astTools.spec.ts
@@ -86,7 +86,7 @@ test('ts2php.AstTools.getIdentities', () => {
   const [ expr ] = srcNode.statements.slice(4, 5);
   const lExp = (expr as ts.SwitchStatement).expression;
 
-  const result = getIdentities(lExp as ts.LeftHandSideExpression, srcNode).map((ident) => ident.getText(srcNode));
+  const result = getIdentities(lExp as ts.LeftHandSideExpression).map((ident) => ident.getText(srcNode));
   expect(result).toBeTruthy();
   expect(result).toMatchObject(['callexp', 'ident1', 'ident2', 'call2', 'ident3', 'ident4', 'ident5', 'ident6']);
 });

--- a/src/__tests__/1_astTools.spec.ts
+++ b/src/__tests__/1_astTools.spec.ts
@@ -6,7 +6,7 @@ import {
   flagParentOfType,
   getChildChainByType,
   getClosestParentOfType,
-  getClosestParentOfTypeWithFlag,
+  getClosestParentOfTypeWithFlag, getIdentities,
   getLeftExpr
 } from '../ts2php/utils/ast';
 import { NodeFlagStore } from '../ts2php/components/codegen/nodeFlagStore';
@@ -75,6 +75,20 @@ test('ts2php.AstTools.leftExpr', () => {
   expect(result).toBeTruthy();
   expect(result?.kind).toEqual(ts.SyntaxKind.Identifier);
   expect(result?.escapedText).toEqual('ident');
+});
+
+test('ts2php.AstTools.getIdentities', () => {
+  const srcNode = compile([path.resolve(__dirname, 'specimens', 'astTools', 'identities.ts')]);
+  if (!srcNode) {
+    throw new Error('File not found');
+  }
+
+  const [ expr ] = srcNode.statements.slice(4, 5);
+  const lExp = (expr as ts.SwitchStatement).expression;
+
+  const result = getIdentities(lExp as ts.LeftHandSideExpression, srcNode).map((ident) => ident.getText(srcNode));
+  expect(result).toBeTruthy();
+  expect(result).toMatchObject(['callexp', 'ident1', 'ident2', 'call2', 'ident3', 'ident4', 'ident5', 'ident6']);
 });
 
 test('ts2php.AstTools.flagParentOfType', () => {

--- a/src/__tests__/2_byType.spec.ts
+++ b/src/__tests__/2_byType.spec.ts
@@ -26,7 +26,7 @@ const testSuiteConfig: Array<{file: string[]; failOnErrors: string[]; expectedEr
   { file: ['byType', 'propertyAccessExpression.ts'], failOnErrors: [], expectedErrors: [] },
   { file: ['byType', 'restOperator.ts'], failOnErrors: [], expectedErrors: [] },
   { file: ['byType', 'spreadOperator.ts'], failOnErrors: [], expectedErrors: ['7e4a6'] },
-  { file: ['byType', 'switchStatement.ts'], failOnErrors: [], expectedErrors: [] },
+  { file: ['byType', 'switchStatement.ts'], failOnErrors: ['6554c'], expectedErrors: [] },
   { file: ['byType', 'templateString.ts'], failOnErrors: [], expectedErrors: ['7cebf'] },
   { file: ['byType', 'tsInternals.ts'], failOnErrors: [], expectedErrors: [] },
 

--- a/src/__tests__/specimens/astTools/identities.ts
+++ b/src/__tests__/specimens/astTools/identities.ts
@@ -1,0 +1,4 @@
+function callexp(..._args: any[]) {}
+function call2(..._args: any[]]) {}
+let ident1, ident2, ident3, ident4, ident5, ident6 = { lol: { kek: 1 }};
+switch (callexp(ident1, ident2, call2(ident3, ident4), typeof ident5, ident6.lol.kek)) {}

--- a/src/__tests__/specimens/byType/SwitchStatementModule.php
+++ b/src/__tests__/specimens/byType/SwitchStatementModule.php
@@ -17,10 +17,37 @@ class SwitchStatementModule extends CJSModule {
     }
 
     public $as;
+    /**
+     * @param mixed ...$args
+     * @return string
+     */
+    public function classNames(...$args) {
+        $result = [];
+        foreach ($args as $item) {
+            if (!$item) {
+                break;
+            }
+            switch (Stdlib::typeof($item)) {
+                case "string":
+                    array_push($result, $item);
+                    break;
+                case "object":
+                    foreach (array_keys($item) as $key) {
+                        if ($item[$key]) {
+                            array_push($result, $key);
+                        }
+                    }
+                    break;
+                default:
+                    array_push($result, (string) $item);
+            }
+        }
+        return implode(" ", $result);
+    }
 
     private function __construct() {
         $this->as = [
-            "v" => 1
+            "v" => 1,
         ];
         switch ($this->as["v"]) {
             case 1:

--- a/src/__tests__/specimens/byType/SwitchStatementModule.php
+++ b/src/__tests__/specimens/byType/SwitchStatementModule.php
@@ -19,8 +19,10 @@ class SwitchStatementModule extends CJSModule {
     public $as;
 
     private function __construct() {
-        $this->as = 1;
-        switch ($this->as) {
+        $this->as = [
+            "v" => 1
+        ];
+        switch ($this->as["v"]) {
             case 1:
                 \VK\Elephize\Builtins\Console::log("lol");
                 break;

--- a/src/__tests__/specimens/byType/switchStatement.ts
+++ b/src/__tests__/specimens/byType/switchStatement.ts
@@ -1,6 +1,6 @@
-let as: any = 1;
+let as: any = { v: 1 };
 
-switch (as) {
+switch (as.v) {
   case 1:
     console.log('lol');
     break;

--- a/src/__tests__/specimens/byType/switchStatement.ts
+++ b/src/__tests__/specimens/byType/switchStatement.ts
@@ -13,3 +13,32 @@ switch (as.v) {
   default:
     console.log('wow');
 }
+
+export function classNames(...args: mixed[]): string {
+  const result: string[] = [];
+
+  args.forEach((item): void => {
+    if (!item) {
+      return;
+    }
+
+    switch (typeof item) {
+      case 'string':
+        result.push(item);
+        break;
+
+      case 'object':
+        Object.keys(item).forEach((key: string) => {
+          if ((item as any)[key]) {
+            result.push(key);
+          }
+        });
+        break;
+
+      default:
+        result.push(String(item));
+    }
+  });
+
+  return result.join(' ');
+}

--- a/src/ts2php/renderers/switchStatement.ts
+++ b/src/ts2php/renderers/switchStatement.ts
@@ -2,16 +2,15 @@ import * as ts from 'typescript';
 import { Declaration } from '../types';
 import { Context } from '../components/context';
 import { isTopLevel } from '../utils/isTopLevel';
-import { normalizeVarName } from '../utils/pathsAndNames';
 import { renderNodes } from '../components/codegen/renderNodes';
-import { getLeftExpr } from '../utils/ast';
+import { getIdentities } from '../utils/ast';
 
 export function tSwitchStatement(node: ts.SwitchStatement, context: Context<Declaration>) {
-  let [usageIdent, arg, block] = renderNodes([getLeftExpr(node.expression) || undefined, node.expression, node.caseBlock], context);
-  const argName = normalizeVarName(usageIdent
-    .replace(/^\$this->/, '')
-    .replace(/^\$/, ''));
-  context.scope.addUsage(argName, [], { terminateLocally: true, dryRun: context.dryRun });
+  let [arg, block] = renderNodes([node.expression, node.caseBlock], context);
+  getIdentities(node.expression).forEach((usageIdent) => {
+    context.scope.addUsage(usageIdent.getText(), [], { terminateLocally: true, dryRun: context.dryRun });
+  });
+
   const expr = `switch (${arg}) {\n${block}\n}`;
   if (isTopLevel(node, context)) {
     context.moduleDescriptor.addStatement(expr);

--- a/src/ts2php/renderers/switchStatement.ts
+++ b/src/ts2php/renderers/switchStatement.ts
@@ -4,10 +4,11 @@ import { Context } from '../components/context';
 import { isTopLevel } from '../utils/isTopLevel';
 import { normalizeVarName } from '../utils/pathsAndNames';
 import { renderNodes } from '../components/codegen/renderNodes';
+import { getLeftExpr } from '../utils/ast';
 
 export function tSwitchStatement(node: ts.SwitchStatement, context: Context<Declaration>) {
-  let [arg, block] = renderNodes([node.expression, node.caseBlock], context);
-  const argName = normalizeVarName(arg
+  let [usageIdent, arg, block] = renderNodes([getLeftExpr(node.expression) || undefined, node.expression, node.caseBlock], context);
+  const argName = normalizeVarName(usageIdent
     .replace(/^\$this->/, '')
     .replace(/^\$/, ''));
   context.scope.addUsage(argName, [], { terminateLocally: true, dryRun: context.dryRun });


### PR DESCRIPTION
Симптом: терялось объявление переменной в случае если она использовалась в составе выражения (например PropertyAccessExpression) внутри switch-проверки.

В чем суть: была наивная логика добавления использования переменной, учитывающая только одиночные идентификаторы.

Что сделано: добавлено чуть менее наивное добавление использований, включающее выражения CallExpression, typeof, а также доступы к свойствам и индексам