### PR TITLE
CLI-опция builtinsNs

### DIFF
--- a/src/ts2php/components/cli/help.ts
+++ b/src/ts2php/components/cli/help.ts
@@ -24,6 +24,7 @@ Options:
    -e / --bail none|warn|error   Return error code if warning/error occurred
                                  during transpilation. Defaults to none.
    -n / --rootNs NAME            Root namespace name for generated classes.
+   -n / --builtinsNs NAME        Define namespace name for rewritten builtins classes.
    -z / --noZap                  Do not remove unused variables from resulting
                                  code. May be useful for debug.
    -v / --verbose                Show more verbose output from transpiler.

--- a/src/ts2php/components/cli/transpile.ts
+++ b/src/ts2php/components/cli/transpile.ts
@@ -14,7 +14,7 @@ const replace = require('stream-replace');
 export function transpile(options: CliOptions, baseDir: string, outDir: string, log: LogObj) {
   const namespaces = {
     root: options.rootNs,
-    builtins: options.rootNs + '\\Builtins',
+    builtins: options.builtinsNs || options.rootNs + '\\Builtins',
   };
 
   glob(options.src, (e: Error, matches: string[]) => {

--- a/src/ts2php/components/codegen/renderModule.ts
+++ b/src/ts2php/components/codegen/renderModule.ts
@@ -34,7 +34,8 @@ export function renderModule(
   registry: ModuleRegistry,
   currentModule: CommonjsModule,
   log: LogObj,
-  disableCodeElimination = false
+  disableCodeElimination = false,
+  builtinsNs = ''
 ): void {
   Scope._forceDisableUnusedVarsElimination = disableCodeElimination;
   const moduleScope = Scope.newRootScope<Declaration>({flags: 0}, currentModule.sourceFileName, log, [
@@ -57,7 +58,8 @@ export function renderModule(
     namespaces,
     encoding,
     registry,
-    log
+    log,
+    builtinsNs
   );
 
   // First pass: build trees and collect var usage info
@@ -85,7 +87,8 @@ export function renderModule(
     namespaces,
     encoding,
     registry,
-    log
+    log,
+    builtinsNs
   );
 
   // Second pass: build code with cleaned unused vars

--- a/src/ts2php/components/context.ts
+++ b/src/ts2php/components/context.ts
@@ -20,7 +20,8 @@ export class Context<T> {
     public readonly namespaces: NsMap,
     public readonly encoding: string,
     public readonly registry: ModuleRegistry,
-    public readonly log: LogObj
+    public readonly log: LogObj,
+    public readonly builtinsNs: string,
   ) { }
 
   public get scope() {

--- a/src/ts2php/types.ts
+++ b/src/ts2php/types.ts
@@ -117,6 +117,7 @@ export type CliOptions = {
     [moduleIdentifier: string]: ImportRule;
   };
   rootNs: string;
+  builtinsNs?: string;
   src: string;
   tsPaths: { [key: string]: string[] };
   verbose: boolean;


### PR DESCRIPTION
Нужно для переписывания встроенных builtins своим кодом, в котором будут происходить нужные трансформации элементов для платформы. Например, чтобы функция render у класса IntrinsicElement возвращала объект, а не строчку