### PR TITLE
Decrease log-level for unexpected extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vkontakte/elephize",
-  "version": "3.1.2",
+  "version": "3.1.1",
   "description": "typescript -> php basic transpiler",
   "main": "src/cli.ts",
   "types": "types/global/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vkontakte/elephize",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "typescript -> php basic transpiler",
   "main": "src/cli.ts",
   "types": "types/global/index.d.ts",

--- a/src/ts2php/components/cjsModules/resolveModules.ts
+++ b/src/ts2php/components/cjsModules/resolveModules.ts
@@ -124,7 +124,7 @@ export const resolveModules = (
       log.info('Module %s was ignored according to library settings', [moduleName]);
     } else if (hasExtension(mPath) && !sourceExtensions.some((ext) => mPath.endsWith(ext))) {
       resolvedModules.push(emptyModule);
-      log.warn('Module %s was found but ignored: not a source file, expected one of following extensions: %s', [moduleName, sourceExtensions.join(',')]);
+      log.info('Module %s was found but ignored: not a source file, expected one of following extensions: %s', [moduleName, sourceExtensions.join(',')]);
     } else {
       if (rule) {
         log.info('Module %s was replaced with implementation %s according to library settings', [moduleName, rule.implementationClass]);


### PR DESCRIPTION
Warnings about css modules currently can't be ignored with `verbose:false`